### PR TITLE
Adding support for annotations on service account

### DIFF
--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ include "codefresh-runner.serviceAccountName" . }}
   namespace: {{ include "codefresh-runner.namespace" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: codefresh-sa
+  annotations: {}
 
 env:
   codefreshToken: <YOUR_TOKEN>


### PR DESCRIPTION
We need the ability to add annotations to the service account, mostly so that we can associate the account w/ IAM roles on EKS (IRSA). 