### PR TITLE
Prefixing resource names w/ helm release name

### DIFF
--- a/templates/delete-configmap.yaml
+++ b/templates/delete-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: delete-script
+  name: {{ .Release.Name }}-delete-script
   namespace: {{ include "codefresh-runner.namespace" . }}
 data:
   delete.sh: |

--- a/templates/delete-job.yaml
+++ b/templates/delete-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: codefresh-runner-deletion
+  name: {{ .Release.Name }}-deletion
   namespace: {{ include "codefresh-runner.namespace" . }}
   annotations:
     "helm.sh/hook": pre-delete
@@ -41,7 +41,7 @@ spec:
       volumes:
         - name: delete-script
           configMap:
-            name: delete-script
+            name: {{ .Release.Name }}-delete-script
             defaultMode: 0777   
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}

--- a/templates/install-configmap.yaml
+++ b/templates/install-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: install-script
+  name: {{ .Release.Name }}-install-script
   namespace: {{ include "codefresh-runner.namespace" . }}
 data:
   install.sh: |

--- a/templates/install-job.yaml
+++ b/templates/install-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: codefresh-runner-installation
+  name: {{ .Release.Name }}-installation
   namespace: {{ include "codefresh-runner.namespace" . }}
   annotations:
     "helm.sh/hook": post-install
@@ -41,7 +41,7 @@ spec:
       volumes:
         - name: install-script
           configMap:
-            name: install-script
+            name: {{ .Release.Name }}-install-script
             defaultMode: 0777               
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: codefresh-user
+  name: {{ .Release.Name }}-codefresh-user
   namespace: {{ include "codefresh-runner.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -24,7 +24,7 @@ subjects:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: codefresh-role
+  name: {{ .Release.Name }}-codefresh-role
   namespace: {{ include "codefresh-runner.namespace" . }}
 rules:
   - apiGroups: [""]
@@ -47,7 +47,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: codefresh-user-cluster
+  name: {{ .Release.Name }}-codefresh-user-cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -61,7 +61,7 @@ subjects:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: codefresh-clusterrole
+  name: {{ .Release.Name }}-codefresh-clusterrole
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -80,7 +80,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: codefresh-user-cluster-admin
+  name: {{ .Release.Name }}-codefresh-user-cluster-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/upgrade-configmap.yaml
+++ b/templates/upgrade-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: upgrade-script
+  name: {{ .Release.Name }}-upgrade-script
   namespace: {{ include "codefresh-runner.namespace" . }}
 data:
   upgrade.sh: |

--- a/templates/upgrade-job.yaml
+++ b/templates/upgrade-job.yaml
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: codefresh-runner-upgrade
+  name: {{ .Release.Name }}-upgrade
   namespace: {{ include "codefresh-runner.namespace" . }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    #"helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:
@@ -41,7 +41,7 @@ spec:
       volumes:
         - name: upgrade-script
           configMap:
-            name: upgrade-script
+            name: {{ .Release.Name }}-upgrade-script
             defaultMode: 0777   
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}


### PR DESCRIPTION
The resource names need to be unique so that we can deploy multiple runners within the same namespace (i.e. multiple helm deployments).

